### PR TITLE
Original oberon report refinement:

### DIFF
--- a/src/procedure.js
+++ b/src/procedure.js
@@ -307,6 +307,8 @@ exports.predefined = [
                     throw new Errors.Error("POINTER variable expected, got '"
                                          + type.name() + "'");
                 this.__baseType = type.baseType();
+                if (this.__baseType === undefined)
+                    throw new Errors.Error("non-exported RECORD type cannot be used in NEW");
                 return new CheckArgumentResult(type, false);
             },
             epilog: function(){
@@ -320,7 +322,7 @@ exports.predefined = [
         var name = "NEW";
         var args = [new Arg(undefined, true)];
         var type = new Std(
-            "NEW",
+            name,
             args,
             undefined,
             function(context, id, type){

--- a/src/type.js
+++ b/src/type.js
@@ -19,7 +19,20 @@ var TypeId = Id.extend({
         this._type = type;
     },
     type: function(){return this._type;},
-    description: function(){return 'type ' + this._type.description();}
+    description: function(){return 'type ' + this._type.description();},
+    strip: function(){this._type = undefined;}
+});
+
+var ForwardTypeId = TypeId.extend({
+    init: function Type$ForwardTypeId(resolve){
+        TypeId.prototype.init.call(this);
+        this.__resolve = resolve;
+    },
+    type: function(){
+        if (!this._type)
+            this._type = this.__resolve();
+        return this._type;
+    }
 });
 
 var LazyTypeId = TypeId.extend({
@@ -91,19 +104,7 @@ exports.Pointer = BasicType.extend({
     description: function(){
         return this.name() || "POINTER TO " + this.baseType().description();
     },
-    baseType: function(){
-        if (this.__base instanceof exports.ForwardRecord)
-            this.__base = this.__base.resolve();
-        return this.__base;
-    }
-});
-
-exports.ForwardRecord = Type.extend({
-    init: function ForwardRecord(resolve){
-        Type.prototype.init.call(this);
-        this.__resolve = resolve;
-    },
-    resolve: function(){return this.__resolve();}
+    baseType: function(){return this.__base.type();}
 });
 
 exports.Record = BasicType.extend({
@@ -216,4 +217,5 @@ exports.ExportedVariable = ExportedVariable;
 exports.Module = Module;
 exports.Type = Type;
 exports.TypeId = TypeId;
+exports.ForwardTypeId = ForwardTypeId;
 exports.LazyTypeId = LazyTypeId;

--- a/test/expected/modules.js
+++ b/test/expected/modules.js
@@ -64,8 +64,15 @@ var anonymous$1 = RTL$.extend({
 	}
 });
 var pr = null;
+var pr2 = null;
 
 function p(){
+}
+
+function makeTPA(){
+	var result = null;
+	result = new TPA();
+	return result;
 }
 pr = new anonymous$1();
 return {
@@ -76,7 +83,9 @@ return {
 	TPA: TPA,
 	i: function(){return i;},
 	pr: function(){return pr;},
-	p: p
+	pr2: function(){return pr2;},
+	p: p,
+	makeTPA: makeTPA
 }
 }();
 var m2 = function (m1){
@@ -93,11 +102,11 @@ function ref(i/*VAR INTEGER*/){
 ptr = new m1.T();
 pb = ptr;
 RTL$.typeGuard(pb, m1.T).i = 123;
-ptrA = new m1.TPA();
+ptrA = m1.makeTPA();
 m1.p();
 p(m1.i());
 p(m1.ci);
-ref(RTL$.makeRef(m1.pr(), "i"));
+ref(RTL$.makeRef(m1.pr2(), "i"));
 }(m1);
 var m3 = function (m1, m2){
 var r = new m2.T();

--- a/test/input/modules.ob
+++ b/test/input/modules.ob
@@ -9,9 +9,17 @@ TYPE
 VAR
     i*: INTEGER;
     pr*: POINTER TO RECORD i: INTEGER END;
+    pr2*: POINTER TO T;
 
 PROCEDURE p*();
 END p;
+
+PROCEDURE makeTPA*(): TPA;
+VAR result: TPA;
+BEGIN
+    NEW(result);
+    RETURN result
+END makeTPA;
 
 BEGIN
     NEW(pr);
@@ -37,12 +45,12 @@ BEGIN
 	pb := ptr;
 	pb(m1.TP).i := 123;
 
-	NEW(ptrA);
+	ptrA := m1.makeTPA();
 
 	m1.p();
     p(m1.i);
     p(m1.ci);
-    ref(m1.pr.i);
+    ref(m1.pr2.i);
 END m2.
 
 MODULE m3;

--- a/test/test_unit.js
+++ b/test/test_unit.js
@@ -1299,6 +1299,22 @@ var testSuite = {
 "import procedure type": testWithModule(
     "MODULE test; TYPE TProc* = PROCEDURE; END test.",
     pass("MODULE m; IMPORT test; VAR proc: test.TProc; END m.")
+    ),
+"imported pointer type cannot be used in NEW if base type is not exported": testWithModule(
+    "MODULE test;"
+    + "TYPE T = RECORD END; TP* = POINTER TO T;"
+    + "TPAnonymous* = POINTER TO RECORD END; END test.",
+    pass(),
+    fail(["MODULE m; IMPORT test; VAR p: test.TPAnonymous; BEGIN NEW(p) END m.",
+          "non-exported RECORD type cannot be used in NEW"],
+         ["MODULE m; IMPORT test; VAR p: test.TP; BEGIN NEW(p) END m.",
+          "non-exported RECORD type cannot be used in NEW"])
+    ),
+"imported pointer variable: anonymous record field cannot be used": testWithModule(
+    "MODULE test; VAR p*: POINTER TO RECORD i: INTEGER END; END test.",
+    pass(),
+    fail(["MODULE m; IMPORT test; BEGIN ASSERT(test.p.i = 0) END m.",
+          "non-exported RECORD type cannot be dereferenced"])
     )
 };
 


### PR DESCRIPTION
Non-exported record types cannot be allocated (NEW) in other modules (using exported pointer type).
Support opaque data types.
